### PR TITLE
Add overloaded edge function to AIAgentSubgraphBuilder

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentSubgraphBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentSubgraphBuilder.kt
@@ -73,6 +73,18 @@ public abstract class AIAgentSubgraphBuilderBase<Input, Output> {
     }
 
     /**
+     * Creates an edge between nodes.
+     * @param edgeIntermediate Intermediate edge builder
+     */
+    public fun <IncomingOutput, OutgoingInput> edge(
+        edgeIntermediate: () -> AIAgentEdgeBuilderIntermediate<IncomingOutput, OutgoingInput, OutgoingInput>
+    ) {
+        val edgeIntermediateBuilder = edgeIntermediate()
+        val edge = AIAgentEdgeBuilder(edgeIntermediateBuilder).build()
+        edgeIntermediateBuilder.fromNode.addEdge(edge)
+    }
+
+    /**
      * Checks if finish node is reachable from start node.
      * @param start Starting node
      * @return True if finish node is reachable


### PR DESCRIPTION
### The 'edge' function takes a lambda as an argument.
```
edge {
    nodeStart forwardTo nodeCallLLM
}
```
---

#### Type of the change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
